### PR TITLE
fix(e2e, playwright): resolved mobile test failures on desktop-layout-component.spec.ts

### DIFF
--- a/e2e/desktop-layout-component.spec.ts
+++ b/e2e/desktop-layout-component.spec.ts
@@ -4,62 +4,74 @@ test.use({ storageState: 'playwright/.auth/certified-user.json' });
 
 test.describe('Classic challenge - 3 pane desktop layout component', () => {
   test('The page has desktop layout with instructions/editor/preview pane', async ({
-    page
+    page,
+    isMobile
   }) => {
+    const desktopLayout = page.getByTestId('desktop-layout');
+    const actionRow = desktopLayout.getByTestId('action-row');
+    const tabsRow = desktopLayout.getByTestId('tabs-row');
+    const reflexContainer = desktopLayout.getByTestId('main-container');
+    const instructionPane = desktopLayout.getByTestId('instruction-pane');
+    const editorPane = desktopLayout.getByTestId('editor-pane');
+    const previewPane = desktopLayout.getByTestId('preview-pane');
+
     await page.goto(
       'learn/2022/responsive-web-design/build-a-survey-form-project/build-a-survey-form'
     );
 
-    const desktopLayout = page.getByTestId('desktop-layout');
-    await expect(desktopLayout).toBeVisible();
-
-    const actionRow = desktopLayout.getByTestId('action-row');
-    await expect(actionRow).toBeVisible();
-
-    const tabsRow = desktopLayout.getByTestId('tabs-row');
-    await expect(tabsRow).toBeVisible();
-
-    const reflexContainer = desktopLayout.getByTestId('main-container');
-    await expect(reflexContainer).toBeVisible();
-
-    const instructionPane = desktopLayout.getByTestId('instruction-pane');
-    await expect(instructionPane).toBeVisible();
-
-    const editorPane = desktopLayout.getByTestId('editor-pane');
-    await expect(editorPane).toBeVisible();
-
-    const previewPane = desktopLayout.getByTestId('preview-pane');
-    await expect(previewPane).toBeVisible();
+    if (isMobile) {
+      await expect(desktopLayout).toBeHidden();
+      await expect(actionRow).toBeHidden();
+      await expect(tabsRow).toBeHidden();
+      await expect(reflexContainer).toBeHidden();
+      await expect(instructionPane).toBeHidden();
+      await expect(editorPane).toBeHidden();
+      await expect(previewPane).toBeHidden();
+    } else {
+      await expect(desktopLayout).toBeVisible();
+      await expect(actionRow).toBeVisible();
+      await expect(tabsRow).toBeVisible();
+      await expect(reflexContainer).toBeVisible();
+      await expect(instructionPane).toBeVisible();
+      await expect(editorPane).toBeVisible();
+      await expect(previewPane).toBeVisible();
+    }
   });
 });
 
 test.describe('Classic challenge - 2 pane desktop layout component', () => {
   test('The page has desktop layout with instructions/editor pane', async ({
-    page
+    page,
+    isMobile
   }) => {
     await page.goto(
       'learn/javascript-algorithms-and-data-structures/basic-javascript/use-recursion-to-create-a-range-of-numbers'
     );
 
     const desktopLayout = page.getByTestId('desktop-layout');
-    await expect(desktopLayout).toBeVisible();
-
     const actionRow = desktopLayout.getByTestId('action-row');
-    await expect(actionRow).not.toBeVisible();
-
     const tabsRow = desktopLayout.getByTestId('tabs-row');
-    await expect(tabsRow).not.toBeVisible();
-
     const reflexContainer = desktopLayout.getByTestId('main-container');
-    await expect(reflexContainer).toBeVisible();
-
     const instructionPane = desktopLayout.getByTestId('instruction-pane');
-    await expect(instructionPane).toBeVisible();
-
     const editorPane = desktopLayout.getByTestId('editor-pane');
-    await expect(editorPane).toBeVisible();
-
     const previewPane = desktopLayout.getByTestId('preview-pane');
-    await expect(previewPane).not.toBeVisible();
+
+    if (isMobile) {
+      await expect(desktopLayout).toBeHidden();
+      await expect(actionRow).toBeHidden();
+      await expect(tabsRow).toBeHidden();
+      await expect(reflexContainer).toBeHidden();
+      await expect(instructionPane).toBeHidden();
+      await expect(editorPane).toBeHidden();
+      await expect(previewPane).toBeHidden();
+    } else {
+      await expect(desktopLayout).toBeVisible();
+      await expect(actionRow).toBeHidden();
+      await expect(tabsRow).toBeHidden();
+      await expect(reflexContainer).toBeVisible();
+      await expect(instructionPane).toBeVisible();
+      await expect(editorPane).toBeVisible();
+      await expect(previewPane).toBeHidden();
+    }
   });
 });


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read and followed the [contribution guidelines](https://contribute.freecodecamp.org).
- [x] I have read and followed the [how to open a pull request guide](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
- [x] My pull request targets the `main` branch of freeCodeCamp.
- [x] I have tested these changes either locally on my machine, or GitPod.

<!-- Feel free to add any additional description of changes below this line -->

## Issue 
The playwright E2E test `desktop-layout-component.spec.ts` fails on mobile browsers such as Chrome and Safari, as it tried accessing a few DOM elements that weren't present in the mobile view. We don't see this failure in CI since mobile tests aren't run on CI (refer to #52198).

Given that we plan to introduce mobile tests on CI in the future, I believe that we should address the root cause of this issue in the test. Therefore, I've made the necessary fix. I've attached the before and after screenshots from Playwright running on my local machine for your reference.

### Expected Behaviour
The test should verify the correct conditions on mobile devices and pass accordingly.

### Before fix
<img width="1269" alt="Screenshot 2023-11-27 at 10 00 20 PM" src="https://github.com/rahulsuresh-git/freeCodeCamp/assets/22114682/410f5694-f1fc-4480-8512-f08d73dbc4d3">

### After fix
<img width="1260" alt="Screenshot 2023-11-27 at 9 35 41 PM" src="https://github.com/rahulsuresh-git/freeCodeCamp/assets/22114682/a72188ca-e59d-42d1-bfe4-9e4aecfe2f22">

